### PR TITLE
Small changes: layout, typo, and formatting

### DIFF
--- a/src/components/CallForPapers.jsx
+++ b/src/components/CallForPapers.jsx
@@ -46,7 +46,7 @@ export function CallForPapers({ id }) {
           <p>
             We would love to see your submission for one or more of these
             topics:
-            <ul class="ml-12 list-outside list-disc">
+            <ul className="ml-12 list-outside list-disc">
               <li>OpenStreetMap</li>
               <li>Community and Foundation</li>
               <li>Mapping</li>
@@ -137,7 +137,7 @@ export function CallForPapers({ id }) {
           </h3>
           <p>
             In rating submissions, we will apply the following criteria:
-            <ul class="ml-12 mt-4 list-outside list-disc space-y-4">
+            <ul className="ml-12 mt-4 list-outside list-disc space-y-4">
               <li>
                 OSM as the subject: A submission where OSM is the main subject
                 or an important ingredient will be rated higher than one that is
@@ -174,7 +174,7 @@ export function CallForPapers({ id }) {
           </p>
           <p>
             Sometimes we will make some changes or have suggestions:
-            <ul class="ml-12 mt-4 list-outside list-disc space-y-4">
+            <ul className="ml-12 mt-4 list-outside list-disc space-y-4">
               <li>We might ask if several speakers can merge their talks.</li>
               <li>
                 We might also ask if a change of format would be possible (for
@@ -218,7 +218,7 @@ export function CallForPapers({ id }) {
             Your submissions will be reviewed by a programme committee
             consisting of OpenStreetMap community members from various parts of
             the world:
-            <ul class="ml-12 mt-4 list-outside list-disc">
+            <ul className="ml-12 mt-4 list-outside list-disc">
               <li>Severin Menard</li>
               <li>Christine Karch </li>
               <li>Tomas Kasparek</li>
@@ -235,7 +235,7 @@ export function CallForPapers({ id }) {
             situations. We try to balance that in the composition of the
             committee. Nevertheless, we have imposed some rules upon ourselves
             to handle conflict of interest situations:
-            <ul class="ml-12 mt-4 list-outside list-disc space-y-4">
+            <ul className="ml-12 mt-4 list-outside list-disc space-y-4">
               <li>
                 We do not rate submissions from our workmates, clients or
                 relatives.
@@ -268,7 +268,7 @@ export function CallForPapers({ id }) {
             Timeline & Deadlines
           </h3>
           <p>
-            <ul class="list-inside list-disc">
+            <ul className="list-inside list-disc">
               <li>July 26: Call for Proposals Opens</li>
               <li>August 24: Deadline for submissions</li>
               <li>August 28: Deadline extended</li>

--- a/src/components/CallForPapers.jsx
+++ b/src/components/CallForPapers.jsx
@@ -271,7 +271,7 @@ export function CallForPapers({ id }) {
             <ul class="list-inside list-disc">
               <li>July 26: Call for Proposals Opens</li>
               <li>August 24: Deadline for submissions</li>
-              <li>August 28: Deadline extented</li>
+              <li>August 28: Deadline extended</li>
               <li>September 21: Speakers notified of final decision</li>
               <li>October 4: Program Announced</li>
               <li>November 10-12: State of the Map Europe 2023</li>

--- a/src/components/CallForPapers.jsx
+++ b/src/components/CallForPapers.jsx
@@ -43,7 +43,7 @@ export function CallForPapers({ id }) {
             Grab this opportunity, contribute to an inspiring and collaborative
             conference and take the stages at State of the Map Europe 2023.
           </p>
-          <p>
+          <div>
             We would love to see your submission for one or more of these
             topics:
             <ul className="ml-12 list-outside list-disc">
@@ -58,7 +58,7 @@ export function CallForPapers({ id }) {
                 <strong>anything</strong> else OSM related
               </li>
             </ul>
-          </p>
+          </div>
           <h3 className="mx-auto mt-6 max-w-2xl text-center font-dunbar text-2xl font-medium tracking-tighter text-sotm-blue sm:text-3xl">
             Submission Types
           </h3>
@@ -135,7 +135,7 @@ export function CallForPapers({ id }) {
           <h3 className="mx-auto mt-6 max-w-2xl text-center font-dunbar text-2xl font-medium tracking-tighter text-sotm-blue sm:text-3xl">
             Rating Criteria
           </h3>
-          <p>
+          <div>
             In rating submissions, we will apply the following criteria:
             <ul className="ml-12 mt-4 list-outside list-disc space-y-4">
               <li>
@@ -171,8 +171,8 @@ export function CallForPapers({ id }) {
                 affiliations and sponsors of their work.
               </li>
             </ul>
-          </p>
-          <p>
+          </div>
+          <div>
             Sometimes we will make some changes or have suggestions:
             <ul className="ml-12 mt-4 list-outside list-disc space-y-4">
               <li>We might ask if several speakers can merge their talks.</li>
@@ -183,7 +183,7 @@ export function CallForPapers({ id }) {
                 complete talk, but an interesting subject).
               </li>
             </ul>
-          </p>
+          </div>
           <h3 className="mx-auto mt-6 max-w-2xl text-center font-dunbar text-2xl font-medium tracking-tighter text-sotm-blue sm:text-3xl">
             Language
           </h3>
@@ -214,7 +214,7 @@ export function CallForPapers({ id }) {
           <h3 className="mx-auto mt-6 max-w-2xl text-center font-dunbar text-2xl font-medium tracking-tighter text-sotm-blue sm:text-3xl">
             Programme Committee
           </h3>
-          <p>
+          <div>
             Your submissions will be reviewed by a programme committee
             consisting of OpenStreetMap community members from various parts of
             the world:
@@ -229,8 +229,8 @@ export function CallForPapers({ id }) {
               <li>Lorenzo Stucchi</li>
               <li>Stefan Keller</li>
             </ul>
-          </p>
-          <p>
+          </div>
+          <div>
             The programme committee is aware of possible conflict of interest
             situations. We try to balance that in the composition of the
             committee. Nevertheless, we have imposed some rules upon ourselves
@@ -253,7 +253,7 @@ export function CallForPapers({ id }) {
                 We report any outside attempt of influencing their decisions.
               </li>
             </ul>
-          </p>
+          </div>
           <p>
             We hope this detailed &ldquo;Call for participation&rdquo; helps to
             increase the transparency of our programme selection process.
@@ -267,7 +267,7 @@ export function CallForPapers({ id }) {
           <h3 className="mx-auto mt-6 max-w-2xl text-center font-dunbar text-2xl font-medium tracking-tighter text-sotm-blue sm:text-3xl">
             Timeline & Deadlines
           </h3>
-          <p>
+          <div>
             <ul className="list-inside list-disc">
               <li>July 26: Call for Proposals Opens</li>
               <li>August 24: Deadline for submissions</li>
@@ -276,7 +276,7 @@ export function CallForPapers({ id }) {
               <li>October 4: Program Announced</li>
               <li>November 10-12: State of the Map Europe 2023</li>
             </ul>
-          </p>
+          </div>
           <div className="text-center">
             <Button className="font-bold" target="_blank" href={url}>
               Submit your presentation

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,16 +1,11 @@
-import { Button } from '@/components/Button'
 import { Container } from '@/components/Container'
 import { DiamondIcon } from '@/components/DiamondIcon'
-// import { Logo } from '@/components/Logo'
 
 export function Header() {
   return (
-    <header className="relative z-50 pb-11 lg:pt-11">
+    <header className="relative z-50">
       <Container className="flex flex-wrap items-center justify-center sm:justify-between lg:flex-nowrap">
-        <div className="mt-10 lg:mt-0 lg:grow lg:basis-0">
-          {/* <Logo className="h-12 w-auto text-slate-900" /> */}
-        </div>
-        <div className="order-first -mx-4 flex flex-auto basis-full overflow-x-auto whitespace-nowrap border-b border-sotm-blue/10 py-4 font-mono text-sm text-sotm-blue sm:-mx-6 lg:order-none lg:mx-0 lg:basis-auto lg:border-0 lg:py-0">
+        <div className="order-first -mx-4 flex flex-auto basis-full overflow-x-auto whitespace-nowrap border-b border-sotm-blue/10 py-4 font-mono text-sm text-sotm-blue">
           <div className="mx-auto flex items-center gap-4 px-4">
             <p>
               <time dateTime="2022-04-04">10</time>-
@@ -19,14 +14,6 @@ export function Header() {
             <DiamondIcon className="h-1.5 w-1.5 overflow-visible fill-current stroke-current text-sotm-yellow" />
             <p>Antwerp, Belgium</p>
           </div>
-        </div>
-        <div className="mx-auto hidden sm:mt-10 sm:flex lg:mt-0 lg:grow lg:basis-0 lg:justify-end">
-          <Button href="https://pretix.eu/sotm-eu/2023/">
-            Get your tickets
-          </Button>
-        </div>
-        <div className="mx-auto hidden sm:mt-10 sm:flex lg:mt-0 lg:grow lg:basis-0 lg:justify-end">
-          <Button href="/call-for-participation">Submit your talks</Button>
         </div>
       </Container>
     </header>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -72,7 +72,7 @@ export function Hero({ id }) {
               strengthening the ongoing projects and collaboration.
             </p>
           </div>
-          <div class="mt-10 grid grid-cols-2 gap-x-10 gap-y-6 sm:mt-16 sm:gap-x-16 sm:gap-y-10 sm:text-center lg:auto-cols-auto lg:grid-flow-col lg:grid-cols-none lg:justify-start lg:text-left">
+          <div className="mt-10 grid grid-cols-2 gap-x-10 gap-y-6 sm:mt-16 sm:gap-x-16 sm:gap-y-10 sm:text-center lg:auto-cols-auto lg:grid-flow-col lg:grid-cols-none lg:justify-start lg:text-left">
             <div className="mx-auto hidden sm:mt-10 sm:flex lg:mt-0 lg:grow lg:basis-0">
               <Button href="https://pretix.eu/sotm-eu/2023/">
                 Get your tickets

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,7 +1,6 @@
 import Image from 'next/image'
 import { useEffect, useState } from 'react'
 
-import { Button } from '@/components/Button'
 import { Container } from '@/components/Container'
 import Logo from '@/images/logos/SOTM_Blue_full_logo_black.png'
 import LogoAntwerpBlue from '@/images/icons/Antwerp_Icon_Blue.svg'
@@ -71,13 +70,6 @@ export function Hero({ id }) {
               support the continued success of the various initiatives by
               strengthening the ongoing projects and collaboration.
             </p>
-          </div>
-          <div className="mt-10 grid grid-cols-2 gap-x-10 gap-y-6 sm:mt-16 sm:gap-x-16 sm:gap-y-10 sm:text-center lg:auto-cols-auto lg:grid-flow-col lg:grid-cols-none lg:justify-start lg:text-left">
-            <div className="mx-auto hidden sm:mt-10 sm:flex lg:mt-0 lg:grow lg:basis-0">
-              <Button href="https://pretix.eu/sotm-eu/2023/">
-                Get your tickets
-              </Button>
-            </div>
           </div>
           <dl className="mt-10 grid grid-cols-2 gap-x-10 gap-y-6 sm:mt-16 sm:gap-x-16 sm:gap-y-10 sm:text-center lg:auto-cols-auto lg:grid-flow-col lg:grid-cols-none lg:justify-start lg:text-left">
             {[

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -1,0 +1,15 @@
+import { Button } from '@/components/Button'
+import { Container } from '@/components/Container'
+
+export function Menu() {
+  return (
+    <nav className="relative z-50 py-11">
+      <Container className="flex flex-wrap items-center justify-center gap-2">
+        <Button href="https://pretix.eu/sotm-eu/2023/" target="_blank">
+          Get your tickets
+        </Button>
+        <Button href="/call-for-participation">Submit your talks</Button>
+      </Container>
+    </nav>
+  )
+}

--- a/src/components/Schedule.jsx
+++ b/src/components/Schedule.jsx
@@ -213,33 +213,19 @@ function ScheduleStatic() {
   )
 }
 
-export function Schedule() {
+export function Schedule({ id }) {
   return (
-    <section id="schedule" aria-label="Schedule" className="py-20 sm:py-32">
-      <Container className="relative z-10">
-        <div className="mx-auto max-w-2xl lg:mx-0 lg:max-w-4xl lg:pr-24">
-          <h2 className="font-poppins text-4xl font-medium tracking-tighter text-sotm-blue sm:text-5xl">
-            Preliminary Schedule
-          </h2>
-          <p className="mt-4 font-poppins text-2xl tracking-tight text-sotm-blue">
-            The conference will be packed with great talks, workshops and
-            opportunities to meet and talk to the OpenStreetMap community.
-          </p>
-        </div>
+    <section id={id} aria-label="Schedule" className="py-20 sm:py-32">
+      <Container className="relative">
+        <h2 className="mx-auto max-w-2xl text-center font-dunbar text-4xl font-medium tracking-tighter text-sotm-blue sm:text-5xl">
+          Preliminary Schedule
+        </h2>
+        <p className="mt-4 font-poppins text-2xl tracking-tight text-sotm-blue">
+          The conference will be packed with great talks, workshops and
+          opportunities to meet and talk to the OpenStreetMap community.
+        </p>
       </Container>
       <div className="relative mt-14 sm:mt-24">
-        <div className="bg-indigo-50 absolute inset-x-0 -bottom-32 -top-40 overflow-hidden">
-          <Image
-            className="absolute left-full top-0 -translate-x-1/2 sm:left-1/2 sm:translate-x-[-20%] sm:translate-y-[-15%] md:translate-x-0 lg:translate-x-[5%] lg:translate-y-[4%] xl:translate-x-[27%] xl:translate-y-[-8%]"
-            src={randomLogo()}
-            alt=""
-            width={918}
-            height={1495}
-            unoptimized
-          />
-          <div className="absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-white" />
-          <div className="absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-white" />
-        </div>
         <Container className="relative">
           <ScheduleTabbed />
           <ScheduleStatic />

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -5,12 +5,11 @@ import { Header } from '@/components/Header'
 import { Hero } from '@/components/Hero'
 import { Newsletter } from '@/components/Newsletter'
 import { Schedule } from '@/components/Schedule'
-import { Speakers } from '@/components/Speakers'
 import { Sponsors } from '@/components/Sponsors'
 import { AboutOsm } from '@/components/AboutOpenStreetMap'
 import { AboutSotm } from '@/components/AboutSotM'
 import { Venue } from '@/components/Venue'
-import { CallForPapersOpen } from '@/components/CallForPapersOpen'
+import { Menu } from '@/components/Menu'
 
 export default function Home() {
   return (
@@ -23,6 +22,7 @@ export default function Home() {
         />
       </Head>
       <Header />
+      <Menu />
       <main>
         <Hero id="hero" />
         <Sponsors id="sponsors" />

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -26,7 +26,7 @@ export default function Home() {
       <main>
         <Hero id="hero" />
         <Sponsors id="sponsors" />
-        <Schedule />
+        <Schedule id="schedule" />
         <Venue id="venue" />
         <AboutOsm id="openstreetmap" />
         <AboutSotm id="stateofthemap" />


### PR DESCRIPTION
- Fix typo: "extented" vs. "extended"
- Formmatting:
  - Don't use `class` but `className` instead
  - Don't use [lists `<ul>`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element) (flow content) in [paragraph `<p>`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element) (can only contain phrasing content)
- Layout:
  - Display "menu" 2 buttons in the header in all screens (including mobile) and center the buttons
  - Use consistent font for Preliminary Schedule section
  - Remove background in Preliminary Schedule section