### PR TITLE
Make "The SotM Europe event" section visible again

### DIFF
--- a/src/components/AboutSotM.jsx
+++ b/src/components/AboutSotM.jsx
@@ -51,7 +51,7 @@ export function AboutSotm({ id }) {
             unoptimized
           />
         </div>
-        <Container>
+        <Container className="relative">
           <h2 className="mx-auto max-w-2xl text-center font-dunbar text-4xl font-medium tracking-tighter text-sotm-blue sm:text-5xl">
             The SotM Europe event
           </h2>


### PR DESCRIPTION
While browsing the [SotM EU 2023 website](https://stateofthemap.eu/), I noticed that the section titled ["The SotM Europe event"](https://stateofthemap.eu/#stateofthemap) is 'there' but the textual content is not currently visible as it is 'hidden' behind the background image of the section. I assume that this was not done intentionally, therefore the change in this pull request adds an attribute that seems missing but required to make the section visible.